### PR TITLE
Makes changes to BaseResource for pydantic v2

### DIFF
--- a/betconnect/resources/baseresource.py
+++ b/betconnect/resources/baseresource.py
@@ -3,8 +3,8 @@ from pydantic import BaseModel
 
 class BaseResource(BaseModel):
     class Config:
-        allow_population_by_field_name = True
-        allow_mutation = True
+        populate_by_name = True
+        frozen = False
         allow = "allow"  # TODO should this be extra = 'allow'
 
     @property


### PR DESCRIPTION
Have been getting warning messages when running flumine about these fields changing in v2, updated based on https://docs.pydantic.dev/latest/migration/

I will need help testing as it seems the tests require connecting to betconnect staging which i don't have

**EDIT**
Just seen this issue https://github.com/betcode-org/betconnect/issues/49